### PR TITLE
Improve efficiency

### DIFF
--- a/lib/xlgen.js
+++ b/lib/xlgen.js
@@ -253,13 +253,15 @@ exports.createXLGen = function (path,options){
 			});
 			ws.on('open', function(){
 				var wrtLen = 0;
+				var allBuf = [];
 				end(function(buffer){
 					if(buffer){
-						ws.write(buffer);
+						// ws.write(buffer);
+						allBuf.push(buffer);
 						wrtLen += buffer.length;
 						//console.log('flush',buffer.length, wrtLen);
 					}else{
-						ws.end();
+						ws.end(Buffer.concat(allBuf, wrtLen));
 					}
 				});
 			});


### PR DESCRIPTION
Hi gutkyu:
I try generate xls file that 100 cols and 3000 rows,it takes 11 minutes.When cells very much,do one write buffer per cell is bad efficiency.

Use 'Buffer.concat' concat all need to write buffer and and write at a time,it only takes 7 seconds and usage more little memory.
